### PR TITLE
Update provider-kubernetes.yaml

### DIFF
--- a/management/providers/provider-kubernetes.yaml
+++ b/management/providers/provider-kubernetes.yaml
@@ -6,7 +6,7 @@ metadata:
 spec:
   package: "crossplanecontrib/provider-kubernetes:main"
   runtimeConfigRef:
-    name: provider-kubernetes-local
+    name: provider-kubernetes
 ---
 apiVersion: kubernetes.crossplane.io/v1alpha1
 kind: ProviderConfig


### PR DESCRIPTION
won't install if provider is named -local. If I'm not mistaken only both ProviderConfig should be renamed